### PR TITLE
[WIP] Integrating Rotten Tomatoes API to greatly improve RT integration

### DIFF
--- a/app/javascript/inject.js
+++ b/app/javascript/inject.js
@@ -118,11 +118,18 @@ function injectRatings(node, ratings) {
 				node.appendChild(imdbSpan());
 			}
 		}
-		if ((rtRating || rtUrl) && !node.querySelector(".rtRating")) {
-			node.appendChild(rtLogoNode(rtUrl));
-			if (rtRating) {
-				node.appendChild(rtRatingNode(rtUrl, rtRating))
-			};
+		if ((rtRating || rtUrl)) {
+			if(!node.querySelector(".rtRating")) {
+				node.appendChild(rtLogoNode(rtUrl));
+				if (rtRating) {
+					node.appendChild(rtRatingNode(rtUrl, rtRating));
+				};
+			} else if (!node.querySelector(".rtRating a")) {
+				node.replaceChild(rtLogoNode(rtUrl), node.querySelectorAll('.rtRating')[0]);
+				if (rtRating) {
+					node.replaceChild(rtRatingNode(rtUrl, rtRating), node.querySelectorAll('.rtRating')[1]);
+				};
+			}
 		}
 		if (metascore && metascore != "N/A" && !node.querySelector(".metacriticRating")) {
 			node.appendChild(metacriticLogoNode());

--- a/app/javascript/omdb.js
+++ b/app/javascript/omdb.js
@@ -33,6 +33,7 @@ function fetchRatings(title, season, episode, year, callback) {
 				};
 				log("Fetched OMDB ratings for " + argsString + ": " + JSON.stringify(ratings));
 				log("Fetching RT ratings for " + argsString);
+				callback(ratings);
 				$.ajax({
 					url: RT_URL,
 					type: "GET",


### PR DESCRIPTION
### Introduction
Hello! Cheers for my first pull request ever! Huge fan of your plugin; been using it since before I began learning programming. 

One thorn in my side has been the fact that the Rotten Tomatoes (henceforce `RT`) integration in OMDB leaves a lot to be desired. I notice people in the Chrome App Store have also complained about the RT integration not working well.

RT exposes their internal API in a way that makes it easy to hook into it without an API key, so we can exploit this fact to greatly improve RT ratings support in RateFlix. 

Here's an example API call if you want to check it out:
```
https://www.rottentomatoes.com/api/private/v2.0/search/?limit=5&q=mission%20impossible
```

### Integrating the Rotten Tomatoes API in `omdb.js`
#### Proposed RT API Call (lines 36-58)
Keeping with your callback style, one solution to integrate the RT API gracefully is to perform a RT AJAX call within the OMDB API call success callback.

This call relies on the success of the OMDB call to use the `response.Title`, `response.Year` and `response.Type` properties to query the RT API.

#### Proposed Parsing for RT API Call (lines 72-91)
In order to handle the RT API response, I have added the function `fetchRTApiInfo(RTResponse, IMDBResponse)`. 

This function updates the ratings object to include the RT rating and relative URL (e.g. `/m/adrift_2018/`) if they exist. 

My switch statement is wired to use the `response.Type` from the IMDB response to differentiate between movie and TV show content. 

The simple searching algorithm in my switch statement first looks to find the correct show using the year (or start year for a TV show), which seems to work about 80% of the time. If this doesn't work, it then grabs the first result in the correct TV show or movie category. This method seems to select the correct show/movie in RT with very high accuracy.
```
84  item = RTResponse.tvSeries.find((show) => show.startYear == year);
85  if (!item) item = RTResponse.tvSeries[0];
```

Note that I am grouping episodes and TV series into the same switch case because RT does not support ratings at the episode-level.

### Updating the view logic in `inject.js`
I propose we exploit the URLs the RT API exposes to make the tomato image and respective rating clickable. I have proposed some simple changes to `inject.js` that make the tomato and rating a link if a URL is available.

Additionally, I have made a minor change on lines 122-124 to still display a clickable tomato icon if a URL is available but not a Tomatometer rating (e.g. Another Cinderella Story on Netflix).

This is an improvement over the current behavior where RT integration is only available if a Tomatometer rating is also available, which isn't always the case for some titles.

### Misc. changes
* On line 134 I have added a polyfill for `Array.prototype.find()`. I chose to add this instead of writing my own searching function for the switch statement on line 78 of `omdb.js`. This seems to be the most performant way for me to support an array search like this without jeopardizing the ES5 compatibility of your codebase.
* fixed `rating` variable reassignment on line 41 of `inject.js`
* fixed global variable declaration on line 9 of `omdb.js`
* renamed `fetchRTRating()` in `omdb.js` to `filterRTRating()` since my proposed changes are now fetching from the RT API.
* Minor changes to the log statements in `omdb.js` to account for RT API integration

### Possible Further Improvements
* One issue with the callback structure I'm adhering to in `omdb.js` is that these calls are very tightly coupled. The Rotten Tomatoes API call only works if the OMDB call works. This seems to be a minor issue in practice, but ideally these would be more independent.
* Another issue with the callback structure is that the calls happen synchronously (the RT API call doesn't start until the OMDB call finishes), which creates a small delay in the data populating. This issue is not big enough to be a show stopper (I'm quite happy with how the app performs even with this problem), but a more ideal solution would use Promise.all() or something similar to allow the calls to happen asynchronously and therefore more quickly.
* Renaming `omdb.js` to `api.js` to better capture the purpose of the file
* Unit tests

### Conclusion
Tried my gosh dang best to conform to your coding style and ES5 compatibility. Let me know if any changes need to be made. Let's get this feature added!